### PR TITLE
stop to use LSGAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,8 @@ python -m pixcaler.run --generator=result/gen_iter_{iteration}.npz --mode up /pa
     * nearest neighbor 法(PIL.Image.NEAREST_NEIGHBOR によるリサイズ)で縮小し、再度64x64に nearest_neighbor 法で拡大したものを変換元、もとの画像を変換先として学習します
 
 #### その他
-* Generater/Discriminater の loss 関数を [LSGAN](https://arxiv.org/abs/1611.04076) に変更(効果があるかは微妙)
-    * 同時に lam1 倍率を100→10に変更してます（経験上、lsgan に換装すると loss は10分の1ぐらいにスケールされる）
-    * [CycleGAN](https://github.com/junyanz/CycleGAN) でも採用されているより安定性の高い loss 関数
-* adversarial loss 倍率を1/16に変更
-    * ドット絵の場合、l1-lossが通常の写真などよりもより小さい値に収束するため、adversarial loss をかなり小さく取らないと学習が不安定になります
-    * なお、この倍率だと、loss の値上は、adversarial loss がほとんど無視されているような挙動になりますが、完全に adversarial loss をなくしてしまうと、出力にノイズが乗るようになり、学習結果が不安定になります
+* adversarial loss 倍率を1/8に変更
+    * ドット絵の場合、l1-lossが通常の写真などよりもより小さい値に収束するため、adversarial loss を小さく取らないと学習が不安定になります
 * pix2pix ネットワークの encoder, decoder の最上段を kernel size 5x5, stride 1, padding 2 の Convolution2D に換装（効果あるのか微妙）
     * もとのネットワークでは画像サイズが128x128以上ないと、画像幅が足りずエラーになります
     * そこで、最上段を5x5のConvolution2D(縮小なし)に換装しました

--- a/pixcaler/updater.py
+++ b/pixcaler/updater.py
@@ -21,15 +21,6 @@ class Pix2PixUpdater(chainer.training.StandardUpdater):
         self.model = kwargs.pop('model')
         super().__init__(*args, **kwargs)
 
-    def loss_func_adv_dis_fake_ls(self, y_fake):
-        return 0.5 * F.mean(y_fake ** 2)
-
-    def loss_func_adv_dis_real_ls(self, y_real):
-        return 0.5 * F.mean((y_real - 1.0) ** 2)
-
-    def loss_func_adv_gen_ls(self, y_fake):
-        return 0.5 * F.mean((y_fake - 1.0) ** 2)
-
     def loss_func_adv_dis_fake(self, y_fake):
         return F.mean(F.softplus(y_fake))
 
@@ -42,9 +33,9 @@ class Pix2PixUpdater(chainer.training.StandardUpdater):
     def loss_func_rec_gen(self, x_in, x_out):
         return F.mean_absolute_error(x_out, x_in)
 
-    def loss_gen(self, enc, x_out, x_in, y_fake, lam1=10, lam2=1/16):
+    def loss_gen(self, enc, x_out, x_in, y_fake, lam1=100, lam2=1/8):
         loss_rec = lam1*self.loss_func_rec_gen(x_in, x_out)
-        loss_adv = lam2*self.loss_func_adv_gen_ls(y_fake)
+        loss_adv = lam2*self.loss_func_adv_gen(y_fake)
         loss = loss_rec + loss_adv
         chainer.report({'loss_rec': loss_rec}, enc)
         chainer.report({'loss_adv': loss_adv}, enc)
@@ -52,8 +43,8 @@ class Pix2PixUpdater(chainer.training.StandardUpdater):
         return loss
 
     def loss_dis(self, dis, y_real, y_fake):
-        L1 = self.loss_func_adv_dis_real_ls(y_real)
-        L2 = self.loss_func_adv_dis_fake_ls(y_fake)
+        L1 = self.loss_func_adv_dis_real(y_real)
+        L2 = self.loss_func_adv_dis_fake(y_fake)
         loss = L1 + L2
         chainer.report({'loss': loss}, dis)
         return loss


### PR DESCRIPTION
Currently, Chainer implementation of pixcaler uses [LSGAN](https://arxiv.org/abs/1611.04076).
(Keras implementation of pixcaler uses [DCGAN](https://arxiv.org/abs/1511.06434). )

However, it may make training unstable.
Noises like the image below may occur in generated images more easily than DCGAN.

![image](https://user-images.githubusercontent.com/1253986/47609815-38993080-da81-11e8-9748-b9bf876c94e7.png)
(original image: https://opengameart.org/content/castle-platformer)
